### PR TITLE
Upgrading to the Clever v2.1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Unofficial OmniAuth strategy for [Clever SSO OAuth2](https://dev.clever.com/sso)
 
 Add the gem to your application's Gemfile:
 
-    gem 'omniauth-clever', '~> 1.2.1'
+    gem 'omniauth-clever', '~> 2.0.0'
 
 And then execute:
 

--- a/lib/omniauth/clever/version.rb
+++ b/lib/omniauth/clever/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Clever
-    VERSION = "1.2.2"
+    VERSION = '2.0.0'.freeze
   end
 end


### PR DESCRIPTION
Clever has deprecated their v1 API so now the `/me` API calls are defaulting to v2.0. In order to get personal information about the user, such as email and name, we need to make follow up API call to the "canonical" URL given in the `/me` response. Here is more information about the "canonical" link: https://dev.clever.com/v2.1/docs/data-model#links

**Why aren't we upgrading to a 3.0 API?**
I wanted to get this change out as fast as possible, and there are probably more changes required to migrate to the 3.0 API.

## Testing Done
Successfully created Student and Teacher accounts using a Clever "Instant Login" link. I was also able to successfully log into those accounts using the same link after logging out.

## Video

https://user-images.githubusercontent.com/1372238/213958718-bec3f92b-150f-4e0f-b693-6820bdc6c461.mov


## Follow up work
* Update the code-dot-org/code-dot-org repo to depend on this version of the omniauth-clever gem.